### PR TITLE
Fix and relax SWORD desposit response parsing and more for Stable 3.1.2

### DIFF
--- a/SwordImportExportPlugin.inc.php
+++ b/SwordImportExportPlugin.inc.php
@@ -207,15 +207,16 @@ class SwordImportExportPlugin extends ImportExportPlugin {
 							if ($depositGalleys) $deposit->addGalleys();
 							if ($depositEditorial) $deposit->addEditorial();
 							$deposit->createPackage();
-							$deposit->deposit(
+							$response = $deposit->deposit(
 								$swordDepositPoint,
 								$username,
 								$password,
 								$request->getUserVar('swordApiKey'));
 
+
 							$stmt_link = array_shift(
 								array_filter($response->sac_links, function($link) {
-									return $link->sac_linkrel == 'http://purl.org/net/sword/terms/statement';
+									return $link->sac_linkrel == 'http://purl.org/net/sword/terms/statement' || $link->sac_linkrel == 'http://purl.org/net/sword/terms/add';
 								}));
 							$stmt_href = $stmt_link->sac_linkhref->__toString();
 							$data = $publishedArticle->getAllData();

--- a/SwordImportExportPlugin.inc.php
+++ b/SwordImportExportPlugin.inc.php
@@ -69,6 +69,13 @@ class SwordImportExportPlugin extends ImportExportPlugin {
 	}
 
 	/**
+	 * @copydoc Plugin::getPluginPath()
+	 */
+	function getPluginPath() {
+		return $this->_parentPlugin->getPluginPath();
+	}
+
+	/**
 	 * Get the display name.
 	 * @return string
 	 */

--- a/classes/OJSSwordDeposit.inc.php
+++ b/classes/OJSSwordDeposit.inc.php
@@ -185,8 +185,8 @@ class OJSSwordDeposit {
 			'http://purl.org/net/sword/package/METSDSpaceSIP',
 			'application/zip', false, true
 		);
-		if ($response->sac_status != 200)
-			throw new Exception($response->sac_summary);
+		if ($response->sac_status > 299)
+			throw new Exception("Status: $response->sac_status , summary: $response->sac_summary");
 		
 		return $response;
 	}


### PR DESCRIPTION
Hi @asmecher,

I came around to push the changes we made locally to make the plugin work with a SWORD endpoint we were testing with. Because the deposit esponse was returning the SWORD statement in a different element but it was still valid for SWORDv2 (see http://swordapp.github.io/SWORDv2-Profile/SWORDProfile.html#depositreceipt)

I also added the missing getPluginPath method for installation from the CLI script.

Best regards,

Nils

EDIT: Fix sword v2 spec link