### PR TITLE
update plugin for compatability with preprint server

### DIFF
--- a/AuthorDepositForm.inc.php
+++ b/AuthorDepositForm.inc.php
@@ -80,9 +80,9 @@ class AuthorDepositForm extends Form {
 	public function execute($request) {
 		$user = $request->getUser();
 		$notificationManager = new NotificationManager();
-		$this->getSwordPlugin()->import('classes.OJSSwordDeposit');
+		$this->getSwordPlugin()->import('classes.PKPSwordDeposit');
 		
-		$deposit = new OJSSwordDeposit($this->_submission);
+		$deposit = new PKPSwordDeposit($this->_submission);
 		$deposit->setMetadata($request);
 		$deposit->addEditorial();
 		$deposit->createPackage();

--- a/SwordImportExportPlugin.inc.php
+++ b/SwordImportExportPlugin.inc.php
@@ -33,21 +33,8 @@ class SwordImportExportPlugin extends ImportExportPlugin {
 	public function register($category, $path, $mainContextId = null) {
 		$success = parent::register($category, $path, $mainContextId);
 		$this->addLocaleData();
-		HookRegistry::register('publishedarticledao::getAdditionalFieldNames', array($this, 'getAdditionalFieldNames'));
 		return $success;
 	}
-
-	/**
-	 * Add statementIRI element to the article
-	 * @param $hookName string
-	 * @param $params array
-	 */
-	function getAdditionalFieldNames($hookName, $params) {
-		$fields =& $params[1];
-		$fields[] = 'swordStatementIri';
-		return false;
-	}
-
 
 	/**
 	 * Get reference to the sword plugin
@@ -117,27 +104,23 @@ class SwordImportExportPlugin extends ImportExportPlugin {
 					'swordSettings'
 				);
 
-				import('lib.pkp.controllers.list.submissions.SelectSubmissionsListHandler');
-				$selectSubmissionsListHandler = new SelectSubmissionsListHandler(array(
-					'title' 	=> 'navigation.submissions',
-					'count' 	=> 100,
-					'inputName' 	=> 'articleId[]',
-					'getParams' => array(
-						'status'	=> STATUS_PUBLISHED,
-					),
-				));
-				$publishedArticleDao = DAORegistry::getDAO('PublishedArticleDAO');
-				$selectSubmissionsConfig = $selectSubmissionsListHandler->getConfig();
-				$depositedIds = [];
-				foreach ($selectSubmissionsConfig['items'] as $item) {
-					$publishedArticle = $publishedArticleDao->getByArticleId($item['id']);
-					if ($ssi = $publishedArticle->getData("swordStatementIri")) {
-						$depositedIds[$item['id']] = $ssi;
-					}
-				}
-				$selectSubmissionsConfig = json_encode($selectSubmissionsConfig);
-
-
+				$selectSubmissionsListPanel = new \PKP\components\listPanels\PKPSelectSubmissionsListPanel(
+					'selectSubmissionsListPanel',
+					'select submissions panel',
+					[
+						'apiUrl' => $request->getDispatcher()->url(
+							$request,
+							ROUTE_API,
+							$context->getPath(),
+							'_submissions'
+						),
+						'canSelect' => true,
+						'canSelectAll' => true,
+						'count' => 100,
+						'lazyLoad' => true,
+						'selectorName' => 'selectedSubmissions[]',
+					]
+				);
 				$templateMgr->assign(array(
 					'selectedDepositPoint' 		=> $request->getUserVar('selectedDepositPoint'),
 					'depositEditorial' 		=> $request->getUserVar('depositEditorial'),
@@ -145,22 +128,28 @@ class SwordImportExportPlugin extends ImportExportPlugin {
 					'swordSettingsPageUrl' 		=> $settingUrl,
 					'depositPoints' 		=> $depositPointsData,
 					'pluginJavaScriptURL' 		=> $this->getSwordPlugin()->getJsUrl($request),
-					'selectSubmissionsListData' 	=> $selectSubmissionsConfig
-				));
+					'selectSubmissionsListData' => [
+						'components' => [
+							'selectSubmissionsListPanel' => $selectSubmissionsListPanel->getConfig()
+						]
+					],
+					'usingApi' => true,
+					));
+
 				$script = '$(document).data("depositedIdMap", '. json_encode($depositedIds) .');';
 				$templateMgr->addJavaScript('depositedIds', $script, ['inline' => true, 'contexts' => 'backend']);
 				$templateMgr->addJavaScript(
 					'disableDepositedIds',
 					$this->getSwordPlugin()->getJsUrl($request) .'/SwordDisableDepositedItems.js',
 					['contexts' => 'backend']);
-				$templateMgr->display($this->_parentPlugin->getTemplateResource('articles.tpl'));
+
+				$templateMgr->display($this->getTemplateResource('submissions.tpl'));
 				break;
 
 			case 'deposit':
 				$context = $request->getContext();
-				$publishedArticleDao = DAORegistry::getDAO('PublishedArticleDAO');
-				$this->getSwordPlugin()->import('classes.OJSSwordDeposit');
-
+				$submissionDao = $this->getSubmissionDAO();
+				$this->getSwordPlugin()->import('classes.PKPSwordDeposit');
 				$depositPointId = $request->getUserVar('depositPoint');
 				$password = $request->getUserVar('swordPassword');
 				if ($password == SWORD_PASSWORD_SLUG) {
@@ -188,19 +177,23 @@ class SwordImportExportPlugin extends ImportExportPlugin {
 				);
 
 				$errors = array();
-				// select at least one article
-				$articleIds = $request->getUserVar('articleId');
-				if (empty($articleIds)) {
+
+				$submissionIds = $request->getUserVar('selectedSubmissions');
+				// select at least one submission
+				if (empty($submissionIds)) {
 					$errors[] = array(
 						'title' => __('plugins.importexport.sword.requiredFieldErrorTitle'),
 						'message' => __('plugins.importexport.sword.requiredFieldErrorMessage'),
 					);
 				}
 				else {
-					foreach ($articleIds as $articleId) {
-						$publishedArticle = $publishedArticleDao->getByArticleId($articleId);
+					foreach ($submissionIds as $submissionId) {
+						$submission = $submissionDao->getById($submissionId);
+						if ($submission->getJournalId() != $request->getJournal()->getId()) {
+							continue;
+						}
 						try {
-							$deposit = new OJSSwordDeposit($publishedArticle);
+							$deposit = new PKPSwordDeposit($submission);
 							$deposit->setMetadata($request);
 							if ($depositGalleys) $deposit->addGalleys();
 							if ($depositEditorial) $deposit->addEditorial();
@@ -211,27 +204,26 @@ class SwordImportExportPlugin extends ImportExportPlugin {
 								$password,
 								$request->getUserVar('swordApiKey'));
 
-
 							$stmt_link = array_shift(
 								array_filter($response->sac_links, function($link) {
 									return $link->sac_linkrel == 'http://purl.org/net/sword/terms/statement' || $link->sac_linkrel == 'http://purl.org/net/sword/terms/add';
 								}));
 							$stmt_href = $stmt_link->sac_linkhref->__toString();
-							$data = $publishedArticle->getAllData();
+							$data = $submission->getAllData();
 							$ssi = [];
 							if (array_has($data, 'swordStatementIri')) {
 								$ssi = unserialize($data['swordStatementIri'], true);
 							}
 							$ssi[$depositPointId] = $stmt_href;
-							$publishedArticle->setData('swordStatementIri', serialize($ssi));
-							$publishedArticleDao->updateDataObjectSettings(
-								'submission_settings', $publishedArticle, ['submission_id' => $articleId]);
+							$submission->setData('swordStatementIri', serialize($ssi));
+							$submissionDao->updateDataObjectSettings(
+								'submission_settings', $submission, ['submission_id' => $submissionId]);
 							$deposit->cleanup();
 							$depositIds[] = $response->sac_id;
 						}
 						catch (Exception $e) {
 							$errors[] = array(
-								'title' => $publishedArticle->getLocalizedTitle(),
+								'title' => $submission->getLocalizedTitle(),
 								'message' => $e->getMessage(),
 							);
 						}
@@ -282,4 +274,9 @@ class SwordImportExportPlugin extends ImportExportPlugin {
 	 */
 	public function usage($scriptName) {
 	}
+
+	protected function getSubmissionDao() {
+		return DAORegistry::getDAO('SubmissionDAO');
+	}
+
 }

--- a/SwordImportExportPlugin.inc.php
+++ b/SwordImportExportPlugin.inc.php
@@ -148,7 +148,7 @@ class SwordImportExportPlugin extends ImportExportPlugin {
 
 			case 'deposit':
 				$context = $request->getContext();
-				$submissionDao = $this->getSubmissionDAO();
+				$submissionDao = Application::getSubmissionDAO();
 				$this->getSwordPlugin()->import('classes.PKPSwordDeposit');
 				$depositPointId = $request->getUserVar('depositPoint');
 				$password = $request->getUserVar('swordPassword');
@@ -189,7 +189,7 @@ class SwordImportExportPlugin extends ImportExportPlugin {
 				else {
 					foreach ($submissionIds as $submissionId) {
 						$submission = $submissionDao->getById($submissionId);
-						if ($submission->getJournalId() != $request->getJournal()->getId()) {
+						if ($submission->getContextId() != $request->getContext()->getId()) {
 							continue;
 						}
 						try {
@@ -274,9 +274,4 @@ class SwordImportExportPlugin extends ImportExportPlugin {
 	 */
 	public function usage($scriptName) {
 	}
-
-	protected function getSubmissionDao() {
-		return DAORegistry::getDAO('SubmissionDAO');
-	}
-
 }

--- a/SwordPlugin.inc.php
+++ b/SwordPlugin.inc.php
@@ -33,13 +33,29 @@ class SwordPlugin extends GenericPlugin {
 				DAORegistry::registerDAO('DepositPointDAO', $depositPointDao);
 
 				HookRegistry::register('LoadHandler', array($this, 'callbackSwordLoadHandler'));
-				HookRegistry::register('Templates::Management::Settings::website', array($this, 'callbackSettingsTab'));
+				HookRegistry::register('Template::Settings::website', array($this, 'callbackSettingsTab'));
 				HookRegistry::register('LoadComponentHandler', array($this, 'setupGridHandler'));
 				HookRegistry::register('EditorAction::recordDecision', array($this, 'callbackAuthorDeposits'));
+				// Preprints
+				HookRegistry::register('Publication::publish', array($this, 'callbackPublish'));
 			}
 			return true;
 		}
 		return false;
+	}
+
+	/**
+	 * Performs automatic deposit on publication
+	 * @param $hookName string
+	 * @param $args array
+	 */
+	public function callbackPublish($hookName, $args) {
+		$newPublication =& $args[0];
+
+		if ($newPublication->getData('status') != STATUS_PUBLISHED) return false;
+		$submission = Services::get('submission')->get($newPublication->getData('submissionId'));
+
+		$this->performAutomaticDeposits($submission);
 	}
 
 	/**
@@ -51,30 +67,37 @@ class SwordPlugin extends GenericPlugin {
 		$submission =& $args[0];
 		$editorDecision =& $args[1];
 		$decision = $editorDecision['decision'];
-
 		// Determine if the decision was an "Accept"
 		if ($decision != SUBMISSION_EDITOR_DECISION_ACCEPT) return false;
 
+		$this->performAutomaticDeposits($submission);
+	}
+
+	/**
+	 * Performs automatic deposits and mails authors
+	 * @param $submission Submission
+	 */
+	function performAutomaticDeposits(Submission $submission) {
 		// Perform Automatic deposits
 		$request =& Registry::get('request');
 		$user = $request->getUser();
 		$context = $request->getContext();
 		$dispatcher = $request->getDispatcher();
-		$this->import('classes.OJSSwordDeposit');
+		$this->import('classes.PKPSwordDeposit');
 		$depositPointDao = DAORegistry::getDAO('DepositPointDAO');
 		$depositPoints = $depositPointDao->getByContextId($context->getId());
 		$sendDepositNotification = $this->getSetting($context->getId(), 'allowAuthorSpecify') ? true : false;
 		while ($depositPoint = $depositPoints->next()) {
 			$depositType = $depositPoint->getType();
-			if (($depositType == SWORD_DEPOSIT_TYPE_OPTIONAL_SELECTION) 
+			if (($depositType == SWORD_DEPOSIT_TYPE_OPTIONAL_SELECTION)
 				|| $depositType == SWORD_DEPOSIT_TYPE_OPTIONAL_FIXED) {
 				$sendDepositNotification = true;
 			}
-			if ($depositType != SWORD_DEPOSIT_TYPE_AUTOMATIC) 
+			if ($depositType != SWORD_DEPOSIT_TYPE_AUTOMATIC)
 				continue;
 
 			try {
-				$deposit = new OJSSwordDeposit($submission);
+				$deposit = new PKPSwordDeposit($submission);
 				$deposit->setMetadata($request);
 				$deposit->addEditorial();
 				$deposit->createPackage();
@@ -99,7 +122,7 @@ class SwordPlugin extends GenericPlugin {
 
 			$user = $request->getUser();
 			$params = array(
-				'itemTitle' => $submission->getLocalizedTitle(), 
+				'itemTitle' => $submission->getLocalizedTitle(),
 				'repositoryName' => $depositPoint->getLocalizedName()
 			);
 			$notificationMgr = new NotificationManager();
@@ -111,23 +134,39 @@ class SwordPlugin extends GenericPlugin {
 		}
 
 		if ($sendDepositNotification) {
-			$submittingUser = $submission->getPrimaryAuthor();  // TODO how to get submission user ?
-			$contactName = $context->getSetting('contactName');
-			$contactEmail = $context->getSetting('contactEmail');
-			import('classes.mail.ArticleMailTemplate');
-			$mail = new ArticleMailTemplate($submission, 'SWORD_DEPOSIT_NOTIFICATION', null, $context, true);
-			$mail->setFrom($contactEmail, $contactName);
-			$mail->addRecipient($submittingUser->getEmail(), $submittingUser->getFullName());
+			$submissionAuthors = [];
+			$dao = new StageAssignmentDAO();
+			$daoResult = $dao->getBySubmissionAndRoleId($submission->getId(), ROLE_ID_AUTHOR);
+			while ($record = $daoResult->next()) {
+				$userId = $record->getData('userId');
+				if (!in_array($userId, $submissionAuthors)) {
+					array_push($submissionAuthors, $userId);
+				}
+			}
 
-			$mail->assignParams(array(
-				'journalName' => $context->getLocalizedName(),
-				'articleTitle' => $submission->getLocalizedTitle(),
-				'swordDepositUrl' => $dispatcher->url(
-					$request, ROUTE_PAGE, null, 'sword', 'index', $submission->getId()
-				)
-			));
+			$userDao = new UserDao();
 
-			$mail->send($request);
+			foreach ($submissionAuthors as $userId) {
+				$submittingUser = $userDao->getById($userId);
+				$contactName = $context->getSetting('contactName');
+				$contactEmail = $context->getSetting('contactEmail');
+
+				import('lib.pkp.classes.mail.SubmissionMailTemplate');
+				$mail = new SubmissionMailTemplate($submission, 'SWORD_DEPOSIT_NOTIFICATION', null, $context, true);
+
+				$mail->setFrom($contactEmail, $contactName);
+				$mail->addRecipient($submittingUser->getEmail(), $submittingUser->getFullName());
+
+				$mail->assignParams(array(
+					'contextName' => $context->getLocalizedName(),
+					'submissionTitle' => $submission->getLocalizedTitle(),
+					'swordDepositUrl' => $dispatcher->url(
+						$request, ROUTE_PAGE, null, 'sword', 'index', $submission->getId()
+					)
+				));
+
+				$mail->send($request);
+			}
 		}
 
 		return false;
@@ -187,9 +226,11 @@ class SwordPlugin extends GenericPlugin {
 	public function callbackSettingsTab($hookName, $args) {
 		$output =& $args[2];
 		$request =& Registry::get('request');
+		$templateMgr = TemplateManager::getManager($request);
 		$dispatcher = $request->getDispatcher();
-		$tabLabel = __('plugins.generic.sword.displayName') . ' ' . __('plugins.generic.sword.settings');
-		$output .= '<li><a name="swordSettings" id="swordSettings" href="' . $dispatcher->url($request, ROUTE_PAGE, null, 'sword', 'swordSettings') . '">' . $tabLabel . '</a></li>';
+		$tabLabel = __('plugins.generic.sword.settingsTabLabel');
+		$templateMgr->assign(['sourceUrl' => $dispatcher->url($request, ROUTE_PAGE, null, 'sword', 'swordSettings')]);
+		$output .= $templateMgr->fetch($this->getTemplateResource('swordSettingsTab.tpl'));
 		return false;
 	}
 
@@ -266,9 +307,9 @@ class SwordPlugin extends GenericPlugin {
 
 	public function getTypeMap() {
 		return array(
-			SWORD_DEPOSIT_TYPE_AUTOMATIC 		=> __('plugins.generic.sword.depositPoints.type.automatic'),
-			SWORD_DEPOSIT_TYPE_OPTIONAL_SELECTION 	=> __('plugins.generic.sword.depositPoints.type.optionalSelection'),
-			SWORD_DEPOSIT_TYPE_OPTIONAL_FIXED 	=> __('plugins.generic.sword.depositPoints.type.optionalFixed'),
+			SWORD_DEPOSIT_TYPE_AUTOMATIC		=> __('plugins.generic.sword.depositPoints.type.automatic'),
+			SWORD_DEPOSIT_TYPE_OPTIONAL_SELECTION	=> __('plugins.generic.sword.depositPoints.type.optionalSelection'),
+			SWORD_DEPOSIT_TYPE_OPTIONAL_FIXED	=> __('plugins.generic.sword.depositPoints.type.optionalFixed'),
 			SWORD_DEPOSIT_TYPE_MANAGER		=> __('plugins.generic.sword.depositPoints.type.manager'),
 		);
 	}
@@ -286,5 +327,31 @@ class SwordPlugin extends GenericPlugin {
 	function getInstallEmailTemplatesFile() {
 		return ($this->getPluginPath() . '/emailTemplates.xml');
 	}
-}
 
+	/**
+	 * @see PKPPlugin::getInstallEmailTemplatesFile()
+	 */
+	function getInstallEmailTemplatesFile() {
+		return ($this->getPluginPath() . '/emailTemplates.xml');
+	}
+
+	/**
+	 * @see PKPPlugin::getInstallEmailTemplateDataFile()
+	 */
+	function getInstallEmailTemplateDataFile() {
+		return ($this->getPluginPath() . '/locale/{$installedLocale}/emailTemplates.xml');
+	}
+
+	/**
+	 * Make sure the installedLocales are set when
+	 * Installer->preInstall is not run, i.e., when
+	 * using the install plugin CLI tool
+	 */
+	function installEmailTemplateData($hookName, $args) {
+		$installer =& $args[0]; /* @var $installer Installer */
+		if (!isset($installer->installedLocales)) {
+			$installer->installedLocales = array_keys(AppLocale::getAllLocales());
+		}
+		parent::installEmailTemplateData($hookName, $args);
+	}
+}

--- a/classes/PKPPackagerMetsSwap.php
+++ b/classes/PKPPackagerMetsSwap.php
@@ -1,0 +1,43 @@
+<?php
+
+require_once dirname(__FILE__) . '/../libs/swordappv2/packager_mets_swap.php';
+
+class PKPPackagerMetsSwap extends PackagerMetsSwap{
+
+	public $sac_name_records = [];
+
+	function writeFileGrp($fh) {
+		if($this->sac_filecount) {
+			parent::writeFileGrp($fh);
+		}
+	}
+
+	function writeDmdSec($fh) {
+		parent::writeDmdSec($fh);
+		if (!empty($this->sac_name_records)) {
+			fwrite($fh, "<dmdSec ID=\"sword-mets-dmd-2\" GROUPID=\"sword-mets-dmd-2_group-2\">\n");
+			fwrite($fh, "<mdWrap LABEL=\"MODS Metadata\" MDTYPE=\"MODS\" MIMETYPE=\"text/xml\">\n");
+			fwrite($fh, "<xmlData>\n");
+			fwrite($fh, "<mods version=\"3.7\" xmlns=\"http://www.loc.gov/mods/v3\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"https://www.loc.gov/standards/mods/xml.xsd\">\n");
+			foreach($this->sac_name_records as $name_record) {
+				fwrite($fh, "<name type=\"personal\">\n");
+				fwrite($fh, "<namePart type=\"given\">" . $name_record['given'] . "</namePart>");
+				fwrite($fh, "<namePart type=\"family\">" . $name_record['family'] . "</namePart>");
+				fwrite($fh, "<nameIdentifier type=\"email\">" . $name_record['email'] . "</nameIdentifier>");
+				fwrite($fh, "<role><roleTerm>author</roleTerm></role>");
+				if ($name_record['primary_contact']){
+					fwrite($fh, "<role><roleTerm>pkp_primary_contact</roleTerm></role>");
+				}
+				fwrite($fh, "</name>\n");
+			}
+			fwrite($fh, "</mods>\n");
+			fwrite($fh, "</xmlData>\n");
+			fwrite($fh, "</mdWrap>\n");
+			fwrite($fh, "</dmdSec>\n");
+		}
+	}
+
+	function setPrimaryAuthor($author) {
+		$this->primaryAuthor = $author;
+	}
+}

--- a/classes/PKPSwordDeposit.inc.php
+++ b/classes/PKPSwordDeposit.inc.php
@@ -15,7 +15,7 @@
 
 require_once dirname(__FILE__) . '/../libs/swordappv2/swordappclient.php';
 require_once dirname(__FILE__) . '/../libs/swordappv2/swordappentry.php';
-require_once dirname(__FILE__) . '/../libs/swordappv2/packager_mets_swap.php';
+require_once dirname(__FILE__) . '/PKPPackagerMetsSwap.php';
 
 class PKPSwordDeposit {
 	/** @var SWORD deposit METS package */
@@ -42,7 +42,7 @@ class PKPSwordDeposit {
 	 * @param $submission Submission
 	 */
 	public function __construct($submission) {
-		$this->_article = $submission;
+		$this->_submission = $submission;
 
 		// Create a directory for deposit contents
 		$this->_outPath = tempnam('/tmp', 'sword');
@@ -51,7 +51,7 @@ class PKPSwordDeposit {
 		mkdir($this->_outPath . '/files');
 
 		// Create a package
-		$this->_package = new PackagerMetsSwap(
+		$this->_package = new PKPPackagerMetsSwap(
 			$this->_outPath,
 			'files',
 			$this->_outPath,
@@ -76,32 +76,23 @@ class PKPSwordDeposit {
 	 */
 	public function setMetadata($request) {
 		$this->_package->setCustodian($this->_context->getContactName());
-		$this->_package->setTitle(html_entity_decode($this->_article->getLocalizedTitle(), ENT_QUOTES, 'UTF-8'));
-		$this->_package->setAbstract(html_entity_decode(strip_tags($this->_article->getLocalizedAbstract()), ENT_QUOTES, 'UTF-8'));
+		$this->_package->setTitle(html_entity_decode($this->_submission->getLocalizedTitle(), ENT_QUOTES, 'UTF-8'));
+		$this->_package->setAbstract(html_entity_decode(strip_tags($this->_submission->getLocalizedAbstract()), ENT_QUOTES, 'UTF-8'));
 		$this->_package->setType($this->_section->getLocalizedIdentifyType());
-
-		// The article can be published or not. Support either.
-		if (is_a($this->_article, 'PublishedArticle')) {
-			$doi = $this->_article->getStoredPubId('doi');
-			if ($doi !== null) $this->_package->setIdentifier($doi);
-		}
-
-		foreach ($this->_article->getAuthors() as $author) {
+		$publication = $this->_submission->getCurrentPublication();
+		foreach ($publication->getData('authors') as $author) {
 			$creator = $author->getFullName(true);
 			$affiliation = $author->getLocalizedAffiliation();
 			if (!empty($affiliation)) $creator .= "; $affiliation";
 			$this->_package->addCreator($creator);
-		}
 
-// 		TODO check with Nate why cistation style plugin is not enabled by default
-// 		also which citation style is DSpace expecting?
-// 		if (is_a($this->_article, 'PublishedArticle')) {
-// 			$plugin = PluginRegistry::getPlugin('generic', 'citationstylelanguageplugin');
-// 			if ($plugin) {
-// 				$citation = $plugin->getCitation($request, $this->_article, 'bibtex');
-// 				$this->_package->setCitation(html_entity_decode(strip_tags($citation), ENT_QUOTES, 'UTF-8'));
-// 			}
-// 		}
+			$this->_package->sac_name_records[] = [
+				'family' => $author->getFamilyName(Locale::getDefault()),
+				'given' => $author->getGivenName(Locale::getDefault()),
+				'email' => $author->getEmail(),
+				'primary_contact' => ($author->getId() === $publication->getData('primaryContactId'))
+			];
+		}
 	}
 
 	/**
@@ -118,7 +109,7 @@ class PKPSwordDeposit {
 	 * Add all article galleys to the deposit package.
 	 */
 	public function addGalleys() {
-		foreach ($this->_article->getGalleys() as $galley) {
+		foreach ($this->_submission->getGalleys() as $galley) {
 			$this->_addFile($galley->getFile());
 		}
 	}
@@ -129,7 +120,7 @@ class PKPSwordDeposit {
 	 */
 	public function addEditorial() {
 		$submissionFileDao = DAORegistry::getDAO('SubmissionFileDAO');
-		$submissionFiles = $submissionFileDao->getBySubmissionId($this->_article->getId());
+		$submissionFiles = $submissionFileDao->getBySubmissionId($this->_submission->getId());
 		// getBySubmission orders results by id ASC, let's reverse the array to have recent files first
 		$submissionFiles = array_reverse($submissionFiles, true);
 		$files = array();

--- a/classes/PKPSwordDeposit.inc.php
+++ b/classes/PKPSwordDeposit.inc.php
@@ -1,21 +1,23 @@
 <?php
 
 /**
- * @file classes/OJSSwordDeposit.inc.php
+ * @file classes/sword/PKPSwordDeposit.inc.php
  *
  * Copyright (c) 2014-2020 Simon Fraser University
  * Copyright (c) 2003-2020 John Willinsky
  * Distributed under the GNU GPL v3. For full terms see the file LICENSE.
  *
- * @class OJSSwordDeposit
- * @brief Class providing a SWORD deposit wrapper for OJS submissions
+ * @class PKPSwordDeposit
+ * @ingroup plugins_generic_sword_classes
+ *
+ * @brief Class providing a SWORD deposit wrapper for submissions
  */
 
 require_once dirname(__FILE__) . '/../libs/swordappv2/swordappclient.php';
 require_once dirname(__FILE__) . '/../libs/swordappv2/swordappentry.php';
 require_once dirname(__FILE__) . '/../libs/swordappv2/packager_mets_swap.php';
 
-class OJSSwordDeposit {
+class PKPSwordDeposit {
 	/** @var SWORD deposit METS package */
 	protected $_package = null;
 
@@ -36,7 +38,7 @@ class OJSSwordDeposit {
 
 	/**
 	 * Constructor.
-	 * Create a SWORD deposit object for an OJS article.
+	 * Create a SWORD deposit object for a submission
 	 * @param $submission Submission
 	 */
 	public function __construct($submission) {
@@ -62,13 +64,9 @@ class OJSSwordDeposit {
 		$sectionDao = DAORegistry::getDAO('SectionDAO');
 		$this->_section = $sectionDao->getById($submission->getSectionId());
 
-		$publishedArticleDao = DAORegistry::getDAO('PublishedArticleDAO');
-		$publishedArticle = $publishedArticleDao->getByArticleId($submission->getId());
-
-		$issueDao = DAORegistry::getDAO('IssueDAO');
-		if ($publishedArticle) {
-			$this->_issue = $issueDao->getById($publishedArticle->getIssueId());
-			$this->_article = $publishedArticle;
+		if (method_exists($submission, 'getIssueId')) {
+			$issueDao = DAORegistry::getDAO('IssueDAO');
+			$this->_issue = $issueDao->getById($submission->getIssueId());
 		}
 	}
 
@@ -185,7 +183,7 @@ class OJSSwordDeposit {
 		);
 		if ($response->sac_status > 299)
 			throw new Exception("Status: $response->sac_status , summary: $response->sac_summary");
-		
+
 		return $response;
 	}
 

--- a/emailTemplates.xml
+++ b/emailTemplates.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE emails SYSTEM "../../../lib/pkp/dtd/emailTemplates.dtd">
-
 <!--
   * emailTemplates.xml
   *

--- a/templates/submissions.tpl
+++ b/templates/submissions.tpl
@@ -55,11 +55,23 @@
 				{fbvElement type="checkbox" id="depositEditorial" value="1" checked=$depositEditorial label="plugins.importexport.sword.depositEditorial"}
 			{/fbvFormSection}
 			{assign var="uuid" value=""|uniqid|escape}
+			{if $usingApi}
+			<div id="select-submissions-{$uuid}">
+				<select-submissions-list-panel
+					v-bind="components.selectSubmissionsListPanel"
+					@set="set"
+					/>
+			</div>
+			<script type="text/javascript">
+				pkp.registry.init('select-submissions-{$uuid}', 'Container', {$selectSubmissionsListData|json_encode});
+			</script>
+			{else}
 			<div id="select-submissions-list-handler-{$uuid}">
 				<script type="text/javascript">
 					pkp.registry.init('select-submissions-list-handler-{$uuid}', 'SelectSubmissionsListPanel', {$selectSubmissionsListData});
 				</script>
 			</div>
+			{/if}
 			{fbvElement type="submit" label="plugins.importexport.sword.deposit" id="depositBtn" inline=true}
 			{fbvElement type="button" label="common.selectAll" id="selectAllBtn" inline=true}
 		</form>

--- a/templates/swordSettingsTab.tpl
+++ b/templates/swordSettingsTab.tpl
@@ -1,0 +1,38 @@
+{**
+ * plugins/generic/sword/templates/swordSettingsTab.tpl
+ *
+ * Copyright (c) 2014-2018 Simon Fraser University
+ * Copyright (c) 2003-2018 John Willinsky
+ * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
+ *
+ * Deposit articles in remote repositories
+ *}
+
+<tab id="swordSettings" label="Sword Settings">
+	<div id="swordGridContainer"><div class="pkp_loading">
+	<span class="pkp_spinner"></span>
+	<span class="message">Loading</span>
+	</div>
+	 </div>
+<script>
+// Initialise JS handler.
+	$(function() {ldelim}
+		$('#swordGridContainer').pkpHandler(
+			'$.pkp.controllers.UrlInDivHandler',
+			{ldelim}
+				sourceUrl: {$sourceUrl|json_encode},
+				refreshOn: null
+			{rdelim}
+		);
+
+		pageUrl = document.location.toString();
+		if (pageUrl.match('#')) {ldelim}
+			pageAnchor = pageUrl.split('#')[1];
+			var $selectedTab = $(".pkpTabs").get(0);
+			if ($selectedTab) {ldelim}
+				$selectedTab.__vue__.setCurrentTab(pageAnchor);
+			{rdelim}
+		{rdelim}
+	{rdelim});
+</script>
+</tab>


### PR DESCRIPTION
@asmecher Updates to the sword plugin for the preprint server. The plugin now checks the version of the application to make some changes in template display, DAO naming, etc. I also added some JS to preserve the tab focus functionality on the plugin settings page - perhaps there is a better way to do that but I could not see it. 

I tested this for Manager-type deposits, but as far as I can tell the "on acceptance" modes of depositing may not apply for preprints. Perhaps those Deposit Point types should be removed in the preprint context?